### PR TITLE
Changed delegateQueue of NSURLSession in ODURLSessionManager to main queue

### DIFF
--- a/OneDriveSDK/OneDriveSDK/ODURLSessionManager/ODURLSessionManager.m
+++ b/OneDriveSDK/OneDriveSDK/ODURLSessionManager/ODURLSessionManager.m
@@ -39,7 +39,7 @@
     self = [super init];
     if (self){
         _urlSessionConfiguration = urlSessionConfiguration;
-        _urlSession = [NSURLSession sessionWithConfiguration:urlSessionConfiguration delegate:self delegateQueue:nil];
+        _urlSession = [NSURLSession sessionWithConfiguration:urlSessionConfiguration delegate:self delegateQueue:[NSOperationQueue mainQueue]];
         _taskDelegates = [NSMutableDictionary dictionary];
     }
     return self;


### PR DESCRIPTION
I had all kinds of weird UI behavior in my app until I figured out that the completionHandlers didn't run on the main thread. And obviously UI stuff has to run on the main thread...
