### PR TITLE
Workaround for ADAL token store lowercasing user ID

### DIFF
--- a/OneDriveSDK.podspec
+++ b/OneDriveSDK.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Auth" do |oda|
     oda.dependency 'ADALiOS', '~> 1.2'
+    oda.dependency 'Base32', '~> 1.1'
     oda.dependency 'OneDriveSDK/Common'
 
     oda.source_files = "OneDriveSDK/Auth/*.{h,m}", "OneDriveSDK/Accounts/*.{h,m}"

--- a/OneDriveSDK/Auth/ODAADAccountBridge.h
+++ b/OneDriveSDK/Auth/ODAADAccountBridge.h
@@ -43,4 +43,16 @@
  */
 + (ODAccountSession *)accountSessionFromCacheItem:(ADTokenCacheStoreItem *)cacheStoreItem serviceInfo:(ODServiceInfo *)serviceInfo;
 
+/**
+ Encodes the input string in a format that will not be semantically changed when ADAL normalizes it
+ @param input The string to be encoded in an ADAL-normalization-safe manner
+ */
++ (NSString*)adalSafeUserIdFromString:(NSString*)input;
+
+/**
+ Decodes the given ADAL-normalization-safe encoded user ID to a plaintext string
+ @param userId The user ID to be decoded from ADAL-normalization-safe form
+ */
++ (NSString*)stringFromAdalSafeUserId:(NSString*)userId;
+
 @end

--- a/OneDriveSDK/Auth/ODBusinessAuthProvider.m
+++ b/OneDriveSDK/Auth/ODBusinessAuthProvider.m
@@ -27,7 +27,6 @@
 #import "ODAuthHelper.h"
 #import "ODAuthConstants.h"
 #import "ODAccountSession.h"
-#import "ODAADAccountBridge.h"
 #import "ODAuthenticationViewController.h"
 
 @interface ODBusinessAuthProvider(){
@@ -113,7 +112,11 @@
 
 - (void)setAccountSessionWithAuthResult:(ADAuthenticationResult *)result
 {
-    self.accountSession = [ODAADAccountBridge accountSessionFromCacheItem:result.tokenCacheStoreItem serviceInfo:self.serviceInfo];
+    self.accountSession = [[ODAccountSession alloc] initWithId:result.tokenCacheStoreItem.userInformation.userId
+                                                   accessToken:result.tokenCacheStoreItem.accessToken
+                                                       expires:result.tokenCacheStoreItem.expiresOn
+                                                  refreshToken:result.tokenCacheStoreItem.refreshToken
+                                                   serviceInfo:self.serviceInfo];
     if (self.accountSession.refreshToken){
         [self.accountStore storeCurrentAccount:self.accountSession];
     }

--- a/OneDriveSDK/Auth/ODKeychainWrapper.m
+++ b/OneDriveSDK/Auth/ODKeychainWrapper.m
@@ -29,6 +29,7 @@
 #import "ODAuthConstants.h"
 #import "ODAADAccountBridge.h"
 #import "ODServiceInfo.h"
+#import "MF_Base32Additions.h"
 
 
 @interface ODKeychainWrapper ()
@@ -63,8 +64,9 @@
 {
     NSParameterAssert(accountId);
     
-    ADTokenCacheStoreKey *accountKey = [self cacheKeyFromAccountId:accountId serviceInfo:serviceInfo];
-    ADTokenCacheStoreItem *item =[self.keychainStore getItemWithKey:accountKey userId:accountId error:nil];
+    NSString *adalSafeUserId = [ODAADAccountBridge adalSafeUserIdFromString:accountId];
+    ADTokenCacheStoreKey *accountKey = [self cacheKeyFromServiceInfo:serviceInfo];
+    ADTokenCacheStoreItem *item =[self.keychainStore getItemWithKey:accountKey userId:adalSafeUserId error:nil];
     ODAccountSession *session = nil;
     if (item){
         session = [ODAADAccountBridge accountSessionFromCacheItem:item serviceInfo:serviceInfo];
@@ -77,15 +79,13 @@
 {
     NSParameterAssert(account);
     
-    ADTokenCacheStoreItem *accountItem = [ODAADAccountBridge cacheItemFromAccountSession:account];
-    ADTokenCacheStoreKey *key = [self cacheKeyFromAccountId:account.accountId serviceInfo:account.serviceInfo];
-    [self.keychainStore removeItemWithKey:key userId:accountItem.userInformation.userId error:nil];
+    NSString *adalSafeUserId = [ODAADAccountBridge adalSafeUserIdFromString:account.accountId];
+    ADTokenCacheStoreKey *key = [self cacheKeyFromServiceInfo:account.serviceInfo];
+    [self.keychainStore removeItemWithKey:key userId:adalSafeUserId error:nil];
 }
 
-- (ADTokenCacheStoreKey *)cacheKeyFromAccountId:(NSString*)accountId serviceInfo:(ODServiceInfo *)serviceInfo
+- (ADTokenCacheStoreKey *)cacheKeyFromServiceInfo:(ODServiceInfo *)serviceInfo
 {
-    NSParameterAssert(accountId);
-    
     return [ADTokenCacheStoreKey keyWithAuthority:serviceInfo.authorityURL resource:serviceInfo.resourceId clientId:serviceInfo.appId error:nil];
 }
 

--- a/OneDriveSDK/Common/ODAuthHelper.m
+++ b/OneDriveSDK/Common/ODAuthHelper.m
@@ -24,7 +24,6 @@
 #import "ODAccountSession.h"
 #import "ODAuthConstants.h"
 #import "ODServiceInfo.h"
-#import "MF_Base32Additions.h"
 
 @implementation ODAuthHelper
 
@@ -67,14 +66,6 @@
         accountId = session[OD_AUTH_TOKEN_ID];
     }
     if (accountId && expires){
-        // HACK: The default account store we use is ADAL, which lowercases user ID.
-        //       User ID seems to sometimes be a case-sensitive string, and we were running
-        //       into an issue where given a saved user ID, we couldn't find the matching
-        //       account session in the account store due to casing mismatch. As a workaround,
-        //       since we only use userId as a key to lookup its associated account session,
-        //       we convert it to Base32 (case insensitive) and lowercase it, thus guaranteeing
-        //       a unique all-lowercase key for any given case-sensitive userId received.
-        accountId = [[accountId base32String] lowercaseString];
         return [[ODAccountSession alloc] initWithId:accountId
                                         accessToken:session[OD_AUTH_ACCESS_TOKEN]
                                             expires:expires

--- a/OneDriveSDK/Common/ODAuthHelper.m
+++ b/OneDriveSDK/Common/ODAuthHelper.m
@@ -24,6 +24,7 @@
 #import "ODAccountSession.h"
 #import "ODAuthConstants.h"
 #import "ODServiceInfo.h"
+#import "MF_Base32Additions.h"
 
 @implementation ODAuthHelper
 
@@ -66,6 +67,14 @@
         accountId = session[OD_AUTH_TOKEN_ID];
     }
     if (accountId && expires){
+        // HACK: The default account store we use is ADAL, which lowercases user ID.
+        //       User ID seems to sometimes be a case-sensitive string, and we were running
+        //       into an issue where given a saved user ID, we couldn't find the matching
+        //       account session in the account store due to casing mismatch. As a workaround,
+        //       since we only use userId as a key to lookup its associated account session,
+        //       we convert it to Base32 (case insensitive) and lowercase it, thus guaranteeing
+        //       a unique all-lowercase key for any given case-sensitive userId received.
+        accountId = [[accountId base32String] lowercaseString];
         return [[ODAccountSession alloc] initWithId:accountId
                                         accessToken:session[OD_AUTH_ACCESS_TOKEN]
                                             expires:expires

--- a/OneDriveSDK/Podfile
+++ b/OneDriveSDK/Podfile
@@ -3,6 +3,7 @@
 
 target 'OneDriveSDK' do
     pod 'ADALiOS', '~> 1.0.2'
+    pod 'Base32', '~> 1.1'
 end
 
 target 'OneDriveSDKTests' do


### PR DESCRIPTION
Workaround issue #85: Turn the case-sensitive userId into a case-insensitive token store key by B32 encoding it as soon as it's received.
