### PR TITLE
Update the currentAccountSession property in [ODAccountStore storeAccount:]

### DIFF
--- a/OneDriveSDK/Auth/ODAccountStore.m
+++ b/OneDriveSDK/Auth/ODAccountStore.m
@@ -191,6 +191,14 @@ static const NSString *ODAccountSessions = @"accountSessions";
     @synchronized(self.accountSessions){
         self.accountSessions[account.accountId] = account;
     }
+    
+    // If 'currentAccountSession' has the same accountID as 'account', update it as well.
+    if(self.currentAccountSession != nil
+       && [self.currentAccountSession.accountId isEqualToString:account.accountId])
+    {
+        self.currentAccountSession = account;
+    }
+    
     [self storeAccounts];
 }
 


### PR DESCRIPTION
Update [ODAccountStore storeAccount:] to set currentAccountSession with the provided parameter only if it has the same 'accountID'. This will fix the bug that cause the app to keep refreshing session because the value in the currentAccountSession property will be used to check for expired date in case [[ODAppConfiguration defaultConfiguration] authProvider] is 'nil'.
