### PR TITLE
Point dependency to ADAL instead of ADALiOS

### DIFF
--- a/OneDriveSDK.podspec
+++ b/OneDriveSDK.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
 
   s.subspec "Auth" do |oda|
-    oda.dependency 'ADALiOS', '~> 1.2'
+    oda.dependency 'ADAL', '~> 1.2.9.1'
     oda.dependency 'Base32', '~> 1.1'
     oda.dependency 'OneDriveSDK/Common'
 

--- a/OneDriveSDK.podspec
+++ b/OneDriveSDK.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
 
   s.subspec "Auth" do |oda|
-    oda.dependency 'ADAL', '~> 1.2.9.1'
+    oda.dependency 'ADAL', '~> 1.2.10'
     oda.dependency 'Base32', '~> 1.1'
     oda.dependency 'OneDriveSDK/Common'
 


### PR DESCRIPTION
ADALiOS name is deprecated, and the needed branch for XCode 9+ uses ‘ADAL’ for the pod name.
As ADAL hasn’t pushed its change, we are left with referencing the pod by git branch, but after the rename cocoapods gets confused.

