### PR TITLE
use xcode 8 for travis builds instead of xcode 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.3
 
 before_install:
     - brew update


### PR DESCRIPTION
Required to update ADAL dependency https://github.com/OneDrive/onedrive-sdk-ios/pull/179