### PR TITLE
update ADALiOS (renamed to ADAL) dependency to version 1.2.10 for xcode 9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.3
 
 before_install:
     - brew update
     - brew outdated xctool || brew upgrade xctool
     - cd OneDriveSDK && pod install
 
-script : 
-    - xctool test -workspace OneDriveSDK.xcworkspace -scheme OneDriveSDKTests -sdk iphonesimulator
+script:
+    - xcodebuild -workspace OneDriveSDK.xcworkspace -scheme OneDriveSDKTests -sdk iphonesimulator build-for-testing
+    - xctool -workspace OneDriveSDK.xcworkspace -scheme OneDriveSDKTests -sdk iphonesimulator run-tests
 

--- a/OneDriveSDK.podspec
+++ b/OneDriveSDK.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
 
   s.subspec "Auth" do |oda|
-    oda.dependency 'ADALiOS', '~> 1.2'
+    oda.dependency 'ADAL', '~> 1.2.10'
     oda.dependency 'Base32', '~> 1.1'
     oda.dependency 'OneDriveSDK/Common'
 


### PR DESCRIPTION
Fixes https://github.com/OneDrive/onedrive-sdk-ios/issues/124

## Checklist
- [X] rename ADALiOS to ADAL and update to version 1.2.10
- [X] use xcode 8.3 for travis tests